### PR TITLE
Redesign PublicDashboard as ambient office display

### DIFF
--- a/src/components/PublicDashboard.tsx
+++ b/src/components/PublicDashboard.tsx
@@ -5,24 +5,9 @@ import { sanityClient } from "@/lib/sanity";
 import { format, formatDistanceToNow } from "date-fns";
 import {
   FileText, FlaskConical, MessageCircle,
-  BookOpen, Search, ChevronDown, Folder,
-  Activity, Download, List, Terminal,
+  BookOpen, Activity, Download, Terminal, Zap,
 } from "lucide-react";
-import { Input } from "@/components/ui/input";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-
-const eventIcons: Record<string, typeof Download> = {
-  "skill.download": Download,
-  "skill.list": List,
-  "user.login": Activity,
-};
 
 const eventLabels: Record<string, string> = {
   "skill.download": "downloaded",
@@ -31,38 +16,44 @@ const eventLabels: Record<string, string> = {
 };
 
 const PublicDashboard = () => {
-  const [skillSearch, setSkillSearch] = useState("");
-  const [selectedSkill, setSelectedSkill] = useState<any | null>(null);
-  const [projectFilter, setProjectFilter] = useState<string>("all");
+  const [now, setNow] = useState(new Date());
 
-  const { data: skills = [], isLoading: skillsLoading } = useQuery({
+  useEffect(() => {
+    const t = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const { data: skills = [] } = useQuery({
     queryKey: ["public-skills"],
     queryFn: () =>
       sanityClient.fetch<any[]>(
         `*[_type == "knowledgeSkill" && published == true] | order(_updatedAt desc) {
-          _id, title, "slug": slug.current, description, tags, project, markdownContent, references, _updatedAt
+          _id, title, "slug": slug.current, description, tags, project, _updatedAt
         }`
       ),
+    refetchInterval: 60000,
   });
 
   const { data: posts = [] } = useQuery({
     queryKey: ["public-posts"],
     queryFn: () =>
       sanityClient.fetch<any[]>(
-        `*[_type == "newsPost" && published == true] | order(publishedAt desc)[0...10] {
+        `*[_type == "newsPost" && published == true] | order(publishedAt desc)[0...6] {
           _id, title, excerpt, category, publishedAt, authorName
         }`
       ),
+    refetchInterval: 60000,
   });
 
   const { data: articles = [] } = useQuery({
     queryKey: ["public-research"],
     queryFn: () =>
       sanityClient.fetch<any[]>(
-        `*[_type == "researchArticle" && published == true] | order(publishedAt desc)[0...10] {
+        `*[_type == "researchArticle" && published == true] | order(publishedAt desc)[0...6] {
           _id, title, abstract, authors, tags, publishedAt
         }`
       ),
+    refetchInterval: 60000,
   });
 
   const { data: tweets = [] } = useQuery({
@@ -76,6 +67,7 @@ const PublicDashboard = () => {
       if (error) throw error;
       return data;
     },
+    refetchInterval: 30000,
   });
 
   const { data: cliEvents = [], refetch: refetchEvents } = useQuery({
@@ -103,7 +95,6 @@ const PublicDashboard = () => {
     return () => { supabase.removeChannel(channel); };
   }, [refetchEvents]);
 
-  // Derive download counts per skill
   const downloadCounts = cliEvents.reduce<Record<string, number>>((acc, ev: any) => {
     if (ev.event_type === "skill.download" && ev.skill_slug) {
       acc[ev.skill_slug] = (acc[ev.skill_slug] || 0) + 1;
@@ -111,152 +102,134 @@ const PublicDashboard = () => {
     return acc;
   }, {});
 
-  const projects = Array.from(new Set(skills.map((s: any) => s.project || "general")));
-
-  const filteredSkills = skills.filter((s: any) => {
-    const matchesProject = projectFilter === "all" || (s.project || "general") === projectFilter;
-    if (!skillSearch.trim()) return matchesProject;
-    const q = skillSearch.toLowerCase();
-    return matchesProject && (
-      s.title?.toLowerCase().includes(q) ||
-      s.description?.toLowerCase().includes(q) ||
-      s.tags?.some((t: string) => t.toLowerCase().includes(q))
-    );
+  const totalDownloads = Object.values(downloadCounts).reduce((a, b) => a + b, 0);
+  const todayEvents = cliEvents.filter((ev: any) => {
+    const d = new Date(ev.created_at);
+    return d.toDateString() === now.toDateString();
   });
 
-  return (
-    <>
-      <div className="grid grid-cols-[1fr_420px] gap-0 h-[calc(100vh-57px)] overflow-hidden">
-        {/* LEFT: Skills (compact) */}
-        <div className="flex flex-col border-r border-border overflow-hidden">
-          <div className="flex-shrink-0 px-5 pt-4 pb-3 border-b border-border">
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-2">
-                <BookOpen className="h-3.5 w-3.5 text-accent" />
-                <h2 className="text-[10px] font-mono uppercase tracking-[0.25em] text-muted-foreground">
-                  Skills & Knowledge
-                </h2>
-              </div>
-              <span className="text-[10px] font-mono text-muted-foreground/50">
-                {filteredSkills.length} skill{filteredSkills.length !== 1 ? "s" : ""}
-              </span>
-            </div>
+  const stats = [
+    { label: "Skills", value: skills.length, icon: BookOpen },
+    { label: "Downloads", value: totalDownloads, icon: Download },
+    { label: "CLI Events", value: cliEvents.length, icon: Terminal },
+    { label: "Active Today", value: todayEvents.length, icon: Zap },
+  ];
 
-            <div className="flex gap-2">
-              <div className="relative flex-1">
-                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
-                <Input
-                  placeholder="Search..."
-                  value={skillSearch}
-                  onChange={(e) => setSkillSearch(e.target.value)}
-                  className="pl-8 h-7 font-mono text-xs bg-secondary border-border"
-                />
+  return (
+    <div className="flex flex-col h-full overflow-hidden bg-background">
+
+      {/* Stats bar */}
+      <div className="flex-shrink-0 grid grid-cols-4 gap-px border-b border-border bg-border">
+        {stats.map((stat) => (
+          <div key={stat.label} className="bg-background px-8 py-5 flex items-center gap-5">
+            <stat.icon className="h-5 w-5 text-accent shrink-0" />
+            <div>
+              <div className="text-4xl font-mono font-bold text-foreground leading-none">
+                {stat.value}
               </div>
-              {projects.length > 1 && (
-                <select
-                  value={projectFilter}
-                  onChange={(e) => setProjectFilter(e.target.value)}
-                  className="h-7 px-2 text-xs font-mono bg-secondary border border-border rounded-md text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                >
-                  <option value="all">All projects</option>
-                  {projects.map((p) => (
-                    <option key={p} value={p}>{p}</option>
-                  ))}
-                </select>
-              )}
+              <div className="text-xs font-mono uppercase tracking-widest text-muted-foreground mt-1">
+                {stat.label}
+              </div>
             </div>
           </div>
+        ))}
+      </div>
 
+      {/* Main grid */}
+      <div className="flex-1 grid grid-cols-[45fr_28fr_27fr] gap-px bg-border overflow-hidden">
+
+        {/* LEFT: Skills */}
+        <div className="bg-background flex flex-col overflow-hidden">
+          <div className="flex-shrink-0 flex items-center justify-between px-8 py-4 border-b border-border">
+            <div className="flex items-center gap-3">
+              <BookOpen className="h-4 w-4 text-accent" />
+              <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+                Skills & Knowledge
+              </span>
+            </div>
+            <span className="text-xs font-mono text-muted-foreground/40">
+              {skills.length} published
+            </span>
+          </div>
           <ScrollArea className="flex-1">
-            {skillsLoading ? (
-              <div className="p-5 space-y-2">
-                {[1, 2, 3, 4, 5].map((i) => (
-                  <div key={i} className="h-10 bg-card border border-border rounded animate-pulse" />
-                ))}
-              </div>
-            ) : filteredSkills.length === 0 ? (
-              <div className="flex items-center justify-center h-full">
-                <p className="text-muted-foreground font-mono text-xs">
-                  {skillSearch || projectFilter !== "all" ? "No matches." : "No skills yet."}
-                </p>
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow className="border-accent/20 hover:bg-transparent">
-                    <TableHead className="w-8 font-mono text-[9px] uppercase tracking-wider text-muted-foreground pl-5">#</TableHead>
-                    <TableHead className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground">Skill</TableHead>
-                    <TableHead className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground w-16 text-center">
-                      <Download className="h-3 w-3 inline-block" />
-                    </TableHead>
-                    <TableHead className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground w-20">Project</TableHead>
-                    <TableHead className="text-right font-mono text-[9px] uppercase tracking-wider text-muted-foreground w-20 pr-5">Updated</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredSkills.map((skill: any, index: number) => {
-                    const slug = skill.slug || skill.title?.toLowerCase().replace(/\s+/g, "-");
-                    const count = downloadCounts[slug] || 0;
-                    return (
-                      <TableRow
-                        key={skill._id}
-                        className="cursor-pointer hover:bg-accent/5 transition-colors"
-                        onClick={() => setSelectedSkill(skill)}
-                      >
-                        <TableCell className="font-mono text-[10px] text-muted-foreground/50 pl-5 py-2">
-                          {index + 1}
-                        </TableCell>
-                        <TableCell className="py-2">
-                          <span className="font-mono text-xs font-medium text-foreground">
-                            {skill.title}
+            <div className="divide-y divide-border">
+              {skills.map((skill: any, i: number) => {
+                const slug = skill.slug || skill.title?.toLowerCase().replace(/\s+/g, "-");
+                const count = downloadCounts[slug] || 0;
+                return (
+                  <div key={skill._id} className="px-8 py-4 flex items-start gap-5">
+                    <span className="text-sm font-mono text-muted-foreground/30 w-6 shrink-0 pt-0.5">
+                      {i + 1}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-3 mb-1">
+                        <span className="font-mono text-base font-medium text-foreground">
+                          {skill.title}
+                        </span>
+                        {skill.project && skill.project !== "general" && (
+                          <span className="text-[11px] font-mono text-accent/60 uppercase tracking-wider">
+                            {skill.project}
                           </span>
-                          {skill.description && (
-                            <p className="text-[11px] text-muted-foreground mt-0.5 line-clamp-1">
-                              {skill.description}
-                            </p>
-                          )}
-                        </TableCell>
-                        <TableCell className="py-2 text-center">
-                          <span className="text-[10px] font-mono text-muted-foreground/60">
-                            {count > 0 ? count : "—"}
-                          </span>
-                        </TableCell>
-                        <TableCell className="py-2">
-                          <span className="text-[10px] font-mono text-muted-foreground/60">
-                            {skill.project || "general"}
-                          </span>
-                        </TableCell>
-                        <TableCell className="text-right font-mono text-[10px] text-muted-foreground pr-5 py-2">
-                          {skill._updatedAt ? format(new Date(skill._updatedAt), "MMM d") : "—"}
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            )}
+                        )}
+                      </div>
+                      {skill.description && (
+                        <p className="text-sm text-muted-foreground leading-snug line-clamp-2">
+                          {skill.description}
+                        </p>
+                      )}
+                      {skill.tags?.length > 0 && (
+                        <div className="flex gap-1.5 mt-2 flex-wrap">
+                          {skill.tags.slice(0, 5).map((tag: string) => (
+                            <span key={tag} className="text-[10px] font-mono uppercase tracking-wider text-accent bg-accent/10 px-1.5 py-0.5 rounded">
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="shrink-0 text-right">
+                      {count > 0 && (
+                        <div className="flex items-center gap-1 text-sm font-mono text-muted-foreground">
+                          <Download className="h-3.5 w-3.5" />
+                          {count}
+                        </div>
+                      )}
+                      <div className="text-xs font-mono text-muted-foreground/40 mt-1">
+                        {skill._updatedAt ? format(new Date(skill._updatedAt), "MMM d") : ""}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+              {skills.length === 0 && (
+                <div className="px-8 py-16 text-center">
+                  <p className="text-muted-foreground font-mono text-sm">No skills published yet.</p>
+                </div>
+              )}
+            </div>
           </ScrollArea>
         </div>
 
-        {/* RIGHT: Thinking + Activity Log + News/Research */}
-        <div className="flex flex-col overflow-hidden">
-          {/* Thinking — larger */}
+        {/* MIDDLE: Thinking + CLI Activity */}
+        <div className="bg-background flex flex-col overflow-hidden">
+
+          {/* Thinking */}
           <div className="flex-[3] flex flex-col overflow-hidden border-b border-border">
-            <div className="flex-shrink-0 px-4 pt-4 pb-2 flex items-center gap-2">
-              <MessageCircle className="h-3 w-3 text-accent" />
-              <h3 className="text-[10px] font-mono uppercase tracking-[0.25em] text-muted-foreground">Thinking</h3>
+            <div className="flex-shrink-0 flex items-center gap-3 px-6 py-4 border-b border-border">
+              <MessageCircle className="h-4 w-4 text-accent" />
+              <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">Thinking</span>
             </div>
-            <ScrollArea className="flex-1 px-4">
-              <div className="space-y-2 pb-3">
+            <ScrollArea className="flex-1">
+              <div className="divide-y divide-border">
                 {tweets.length === 0 ? (
-                  <p className="text-muted-foreground/50 font-mono text-[10px] py-4 text-center">—</p>
+                  <p className="px-6 py-8 text-sm font-mono text-muted-foreground/40 text-center">—</p>
                 ) : (
-                  tweets.slice(0, 12).map((tweet) => (
-                    <div key={tweet.id} className="border-l-2 border-accent/30 pl-3 py-1">
-                      <p className="text-xs text-foreground/80 font-sans leading-relaxed line-clamp-3">
+                  tweets.slice(0, 10).map((tweet) => (
+                    <div key={tweet.id} className="px-6 py-4">
+                      <p className="text-sm text-foreground/90 leading-relaxed">
                         {tweet.content}
                       </p>
-                      <span className="text-[10px] font-mono text-muted-foreground/50 mt-0.5 block">
+                      <span className="text-[11px] font-mono text-muted-foreground/50 mt-2 block">
                         {tweet.author_name && `${tweet.author_name} · `}
                         {format(new Date(tweet.created_at), "MMM d · HH:mm")}
                       </span>
@@ -267,47 +240,45 @@ const PublicDashboard = () => {
             </ScrollArea>
           </div>
 
-          {/* Activity Log */}
-          <div className="flex-[2] flex flex-col overflow-hidden border-b border-border">
-            <div className="flex-shrink-0 px-4 pt-3 pb-2 flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Terminal className="h-3 w-3 text-accent" />
-                <h3 className="text-[10px] font-mono uppercase tracking-[0.25em] text-muted-foreground">CLI Activity</h3>
+          {/* CLI Activity */}
+          <div className="flex-[2] flex flex-col overflow-hidden">
+            <div className="flex-shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
+              <div className="flex items-center gap-3">
+                <Terminal className="h-4 w-4 text-accent" />
+                <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">CLI Activity</span>
               </div>
-              <span className="text-[10px] font-mono text-muted-foreground/50">
-                {cliEvents.length} event{cliEvents.length !== 1 ? "s" : ""}
+              <span className="flex items-center gap-1.5">
+                <span className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
+                <span className="text-[11px] font-mono text-muted-foreground/40">live</span>
               </span>
             </div>
-            <ScrollArea className="flex-1 px-4">
-              <div className="space-y-1 pb-3">
+            <ScrollArea className="flex-1">
+              <div className="divide-y divide-border">
                 {cliEvents.length === 0 ? (
-                  <p className="text-muted-foreground/50 font-mono text-[10px] py-4 text-center">No activity yet</p>
+                  <p className="px-6 py-8 text-sm font-mono text-muted-foreground/40 text-center">No activity yet</p>
                 ) : (
                   cliEvents.map((ev: any) => {
-                    const Icon = eventIcons[ev.event_type] || Activity;
                     const label = eventLabels[ev.event_type] || ev.event_type;
                     return (
-                      <div key={ev.id} className="flex items-start gap-2 py-1 group">
-                        <Icon className="h-3 w-3 text-accent/60 mt-0.5 shrink-0" />
+                      <div key={ev.id} className="px-6 py-3 flex items-start gap-3">
+                        <Activity className="h-3.5 w-3.5 text-accent/60 mt-0.5 shrink-0" />
                         <div className="flex-1 min-w-0">
-                          <p className="text-[11px] font-mono text-foreground/80 leading-tight">
+                          <p className="text-sm font-mono text-foreground/80 leading-tight">
                             {ev.event_type === "user.login" ? (
                               <>
                                 <span className="text-accent">{ev.user_name || ev.user_email?.split("@")[0] || "user"}</span>
-                                {" "}
-                                <span className="text-muted-foreground">{label}</span>
+                                {" "}<span className="text-muted-foreground">{label}</span>
                               </>
                             ) : ev.skill_slug ? (
                               <>
                                 <span className="text-accent">{ev.skill_title || ev.skill_slug}</span>
-                                {" "}
-                                <span className="text-muted-foreground">{label}</span>
+                                {" "}<span className="text-muted-foreground">{label}</span>
                               </>
                             ) : (
                               <span className="text-muted-foreground">{label}</span>
                             )}
                           </p>
-                          <span className="text-[9px] font-mono text-muted-foreground/40">
+                          <span className="text-[11px] font-mono text-muted-foreground/40">
                             {formatDistanceToNow(new Date(ev.created_at), { addSuffix: true })}
                           </span>
                         </div>
@@ -318,25 +289,48 @@ const PublicDashboard = () => {
               </div>
             </ScrollArea>
           </div>
+        </div>
 
-          {/* News + Research (compact) */}
+        {/* RIGHT: News + Research + Clock */}
+        <div className="bg-background flex flex-col overflow-hidden">
+
+          {/* Clock */}
+          <div className="flex-shrink-0 px-6 py-5 border-b border-border flex items-baseline justify-between">
+            <span className="text-4xl font-mono font-bold text-foreground tabular-nums">
+              {format(now, "HH:mm")}
+            </span>
+            <span className="text-sm font-mono text-muted-foreground/60">
+              {format(now, "EEE MMM d")}
+            </span>
+          </div>
+
+          {/* News */}
           <div className="flex-[1] flex flex-col overflow-hidden border-b border-border">
-            <div className="flex-shrink-0 px-4 pt-3 pb-2 flex items-center gap-2">
-              <FileText className="h-3 w-3 text-accent" />
-              <h3 className="text-[10px] font-mono uppercase tracking-[0.25em] text-muted-foreground">News</h3>
+            <div className="flex-shrink-0 flex items-center gap-3 px-6 py-4 border-b border-border">
+              <FileText className="h-4 w-4 text-accent" />
+              <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">News</span>
             </div>
-            <ScrollArea className="flex-1 px-4">
-              <div className="space-y-1 pb-2">
+            <ScrollArea className="flex-1">
+              <div className="divide-y divide-border">
                 {posts.length === 0 ? (
-                  <p className="text-muted-foreground/50 font-mono text-[10px] py-2 text-center">—</p>
+                  <p className="px-6 py-6 text-sm font-mono text-muted-foreground/40 text-center">—</p>
                 ) : (
-                  posts.slice(0, 4).map((post: any) => (
-                    <div key={post._id} className="flex items-start justify-between gap-2 py-0.5">
-                      <span className="font-mono text-[11px] text-foreground line-clamp-1 flex-1 min-w-0">{post.title}</span>
-                      {post.publishedAt && (
-                        <span className="text-[9px] font-mono text-muted-foreground/50 shrink-0">
-                          {format(new Date(post.publishedAt), "MMM d")}
+                  posts.map((post: any) => (
+                    <div key={post._id} className="px-6 py-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <span className="font-mono text-sm font-medium text-foreground leading-snug">
+                          {post.title}
                         </span>
+                        {post.publishedAt && (
+                          <span className="text-[11px] font-mono text-muted-foreground/50 shrink-0 mt-0.5">
+                            {format(new Date(post.publishedAt), "MMM d")}
+                          </span>
+                        )}
+                      </div>
+                      {post.excerpt && (
+                        <p className="text-xs text-muted-foreground mt-1 line-clamp-2 leading-snug">
+                          {post.excerpt}
+                        </p>
                       )}
                     </div>
                   ))
@@ -345,23 +339,33 @@ const PublicDashboard = () => {
             </ScrollArea>
           </div>
 
+          {/* Research */}
           <div className="flex-[1] flex flex-col overflow-hidden">
-            <div className="flex-shrink-0 px-4 pt-3 pb-2 flex items-center gap-2">
-              <FlaskConical className="h-3 w-3 text-accent" />
-              <h3 className="text-[10px] font-mono uppercase tracking-[0.25em] text-muted-foreground">Research</h3>
+            <div className="flex-shrink-0 flex items-center gap-3 px-6 py-4 border-b border-border">
+              <FlaskConical className="h-4 w-4 text-accent" />
+              <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">Research</span>
             </div>
-            <ScrollArea className="flex-1 px-4">
-              <div className="space-y-1 pb-2">
+            <ScrollArea className="flex-1">
+              <div className="divide-y divide-border">
                 {articles.length === 0 ? (
-                  <p className="text-muted-foreground/50 font-mono text-[10px] py-2 text-center">—</p>
+                  <p className="px-6 py-6 text-sm font-mono text-muted-foreground/40 text-center">—</p>
                 ) : (
-                  articles.slice(0, 4).map((article: any) => (
-                    <div key={article._id} className="flex items-start justify-between gap-2 py-0.5">
-                      <span className="font-mono text-[11px] text-foreground line-clamp-1 flex-1 min-w-0">{article.title}</span>
-                      {article.publishedAt && (
-                        <span className="text-[9px] font-mono text-muted-foreground/50 shrink-0">
-                          {format(new Date(article.publishedAt), "MMM d")}
+                  articles.map((article: any) => (
+                    <div key={article._id} className="px-6 py-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <span className="font-mono text-sm font-medium text-foreground leading-snug">
+                          {article.title}
                         </span>
+                        {article.publishedAt && (
+                          <span className="text-[11px] font-mono text-muted-foreground/50 shrink-0 mt-0.5">
+                            {format(new Date(article.publishedAt), "MMM d")}
+                          </span>
+                        )}
+                      </div>
+                      {article.abstract && (
+                        <p className="text-xs text-muted-foreground mt-1 line-clamp-2 leading-snug">
+                          {article.abstract}
+                        </p>
                       )}
                     </div>
                   ))
@@ -371,106 +375,7 @@ const PublicDashboard = () => {
           </div>
         </div>
       </div>
-
-      {/* Skill Detail Modal */}
-      <Dialog open={!!selectedSkill} onOpenChange={(open) => !open && setSelectedSkill(null)}>
-        <DialogContent className="w-[680px] max-w-[90vw] max-h-[85vh] overflow-y-auto overflow-x-hidden bg-card border-border">
-          {selectedSkill && (
-            <>
-              <DialogHeader>
-                <p className="text-xs font-mono text-muted-foreground mb-1">
-                  skills / <span className="text-accent">{selectedSkill.slug || selectedSkill.title?.toLowerCase().replace(/\s+/g, "-")}</span>
-                </p>
-                <DialogTitle className="font-mono text-lg font-medium text-foreground">
-                  {selectedSkill.title}
-                </DialogTitle>
-              </DialogHeader>
-
-              {selectedSkill.description && (
-                <div className="bg-secondary/50 border border-border rounded-md p-4 mt-2">
-                  <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-2">Summary</p>
-                  <p className="text-sm text-foreground/80 leading-relaxed">{selectedSkill.description}</p>
-                </div>
-              )}
-
-              <div className="flex items-center justify-between mt-2 flex-wrap gap-2">
-                <div className="flex items-center gap-1.5 flex-wrap">
-                  {selectedSkill.project && selectedSkill.project !== "general" && (
-                    <Badge variant="secondary" className="text-[10px] font-mono uppercase tracking-wider text-foreground bg-secondary border border-border">
-                      <Folder className="h-2.5 w-2.5 mr-1" />
-                      {selectedSkill.project}
-                    </Badge>
-                  )}
-                  {selectedSkill.tags?.map((tag: string) => (
-                    <Badge key={tag} variant="secondary" className="text-[10px] font-mono uppercase tracking-wider text-accent bg-accent/10 border-0">
-                      {tag}
-                    </Badge>
-                  ))}
-                </div>
-                <div className="flex items-center gap-3">
-                  {(() => {
-                    const slug = selectedSkill.slug || selectedSkill.title?.toLowerCase().replace(/\s+/g, "-");
-                    const count = downloadCounts[slug] || 0;
-                    return count > 0 ? (
-                      <span className="text-[10px] font-mono text-muted-foreground flex items-center gap-1">
-                        <Download className="h-3 w-3" /> {count}
-                      </span>
-                    ) : null;
-                  })()}
-                  {selectedSkill._updatedAt && (
-                    <span className="text-xs font-mono text-muted-foreground">
-                      {format(new Date(selectedSkill._updatedAt), "MMM d, yyyy")}
-                    </span>
-                  )}
-                </div>
-              </div>
-
-              {selectedSkill.markdownContent && (
-                <>
-                  <Separator className="my-2" />
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <FileText className="h-3.5 w-3.5 text-accent" />
-                    <span className="text-xs font-mono uppercase tracking-wider text-muted-foreground">skill.md</span>
-                  </div>
-                  <div className="skill-prose max-w-none break-words overflow-wrap-anywhere">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                      {selectedSkill.markdownContent}
-                    </ReactMarkdown>
-                  </div>
-                </>
-              )}
-
-              {selectedSkill.references?.length > 0 && (
-                <>
-                  <Separator className="my-2" />
-                  <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-2">Reference Files</p>
-                  <div className="space-y-1">
-                    {selectedSkill.references.map((ref: any, i: number) => (
-                      <Collapsible key={ref._key || i}>
-                        <CollapsibleTrigger className="flex items-center gap-1.5 w-full text-left py-1.5 px-2 rounded hover:bg-accent/5 transition-colors group">
-                          <FileText className="h-3 w-3 text-accent" />
-                          <span className="text-xs font-mono text-foreground group-hover:text-accent transition-colors">
-                            {ref.folder ? `${ref.folder}/` : ""}{ref.filename}
-                          </span>
-                          <ChevronDown className="h-3 w-3 text-muted-foreground ml-auto group-data-[state=open]:rotate-180 transition-transform" />
-                        </CollapsibleTrigger>
-                        <CollapsibleContent>
-                          <div className="ml-5 mt-1 mb-2 skill-prose max-w-none">
-                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                              {ref.content || ""}
-                            </ReactMarkdown>
-                          </div>
-                        </CollapsibleContent>
-                      </Collapsible>
-                    ))}
-                  </div>
-                </>
-              )}
-            </>
-          )}
-        </DialogContent>
-      </Dialog>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

- Replaces cramped `1fr/420px` two-column layout with `45/28/27` three-column grid
- Adds stats bar across the top with big readable numbers (Skills, Downloads, CLI Events, Active Today)
- Live clock (HH:mm + date) in the right column, ticking every second
- All content text bumped to `text-sm`/`text-base` minimum — readable from across the room
- Skills list shows full description (2-line clamp) + tags
- News and Research show excerpts/abstracts instead of title-only rows
- Removed search bar, project filter, and skill detail modal — no interaction needed on an ambient display
- Added `refetchInterval` on all data sources for automatic updates
- Live pulse dot on CLI activity feed

## Test plan

- [ ] Loads correctly on a 16:9 screen without horizontal scroll
- [ ] Stats bar reflects correct counts
- [ ] Clock ticks live
- [ ] CLI activity feed updates in real time via Supabase subscription
- [ ] All three columns fill the viewport height

🤖 Generated with [Claude Code](https://claude.com/claude-code)