### PR TITLE
Fix triage_tasks querying non-existent source_agent column

### DIFF
--- a/supabase/functions/mcp-server/index.ts
+++ b/supabase/functions/mcp-server/index.ts
@@ -1634,7 +1634,7 @@ async function handleTool(name: string, args: any, user: { email: string; userId
 
     case "triage_tasks": {
       const sb = adminClient();
-      const { data, error } = await sb.from("tasks").select("task_number, title, source, source_agent, confidence, created_at").eq("requires_triage", true).is("archived_at", null).order("created_at", { ascending: false }).limit(args.limit || 20);
+      const { data, error } = await sb.from("tasks").select("task_number, title, source, confidence, created_at").eq("requires_triage", true).is("archived_at", null).order("created_at", { ascending: false }).limit(args.limit || 20);
       if (error) return [{ type: "text", text: `Error: ${error.message}` }];
       if (!data?.length) return [{ type: "text", text: "No tasks need triage." }];
       const out = data.map((t: any) => `#${t.task_number} [${t.source}${t.confidence ? ` ${(t.confidence * 100).toFixed(0)}%` : ""}] ${t.title}`).join("\n");


### PR DESCRIPTION
## Summary
- Remove `source_agent` from the `triage_tasks` select query — this column doesn't exist in the DB schema, causing the endpoint to crash with a DB error
- Fixes feedback from Mikael about `triage_tasks` failing with "column tasks.source_agent does not exist"

## Test plan
- [ ] Run `triage_tasks` via MCP and verify it no longer returns a DB error
- [ ] Verify triage output still shows source and confidence for each task

🤖 Generated with [Claude Code](https://claude.com/claude-code)